### PR TITLE
Make it easy to profile parsing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,7 +21,8 @@ switch (argv._[0]) {
   case "parse":
     parseCommand({
       debug: argv.d || argv.debug,
-      codePath: argv._[1]
+      codePath: argv._[1],
+      print: argv.print !== false
     });
     break;
 

--- a/cli.js
+++ b/cli.js
@@ -22,8 +22,10 @@ switch (argv._[0]) {
     parseCommand({
       debug: argv.d || argv.debug,
       codePath: argv._[1],
-      print: argv.print !== false
-    });
+      print: argv.print,
+      profile: argv.profile,
+      repeat: argv.repeat
+    }, process.exit);
     break;
 
   case undefined:

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,4 +1,4 @@
-const tmp = require("temp").track(),
+const tmp = require("temp"),
       spawnSync = require("child_process").spawnSync,
       fs = require("fs"),
       path = require("path"),

--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -24,8 +24,13 @@ module.exports = function test(options, callback) {
   document.parse();
   var t1 = Date.now();
 
-  printNode(document.rootNode, 0);
-  process.stdout.write("\n");
+  if (options.print) {
+    printNode(document.rootNode, 0);
+    process.stdout.write("\n");
+  } else if (document.rootNode.toString().indexOf('ERROR') !== -1) {
+    console.log("Error detected")
+    process.exit(1)
+  }
 
   console.log("Finished in %d milliseconds", t1 - t0);
 };

--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -1,4 +1,4 @@
-module.exports = function test(options, callback) {
+module.exports = function parse(options, callback) {
   var fs = require("fs"),
       path = require("path"),
       cwd = process.cwd(),
@@ -6,6 +6,12 @@ module.exports = function test(options, callback) {
       Document = require("tree-sitter").Document;
 
   var document = new Document().setLanguage(language);
+
+  if (options.repeat) {
+    console.log("Benchmarking with %d repetitions", options.repeat);
+  } else {
+    options.repeat = 1;
+  }
 
   if (options.debug)
     document.setDebugger(function(topic, params, type) {
@@ -18,21 +24,94 @@ module.exports = function test(options, callback) {
       }
     });
 
+  if (options.profile) {
+    var spawn = require("child_process").spawn;
+    var temp = require("temp");
+    var dtraceOutputFile = temp.openSync({prefix: 'dtrace.out'});
+    var flamegraphFile = temp.openSync({prefix: 'flamegraph', suffix: '.html'});
+    fs.chmodSync(flamegraphFile.path, '755');
+
+    var dtraceProcess = spawn("dtrace", [
+      "-x", "ustackframes=100",
+      "-n", "profile-2000 /pid == $target/ { @num[ustack()] = count(); }",
+      "-c", process.argv[0] + " -e require('" + __filename + "')({print:false,codePath:'" + options.codePath + "',repeat:" + options.repeat + "},process.exit);"
+    ], {
+      stdio: ['ignore', dtraceOutputFile.fd, process.stderr]
+    });
+
+    dtraceProcess.on('close', function(code) {
+      if (code !== 0) {
+        return callback(code);
+      }
+
+      fs.closeSync(dtraceOutputFile.fd);
+      var dtraceOutput = fs.readFileSync(dtraceOutputFile.path, 'utf8');
+      var dtraceStacks = dtraceOutput.split("\n\n");
+
+      var stackvisProcess = spawn(path.join(__dirname, '..', '..', 'node_modules', '.bin', 'stackvis'), [], {
+        stdio: ['pipe', flamegraphFile.fd, process.stderr]
+      });
+
+      var filteredOutput = dtraceOutput
+        .split('\n\n')
+        .map(function (stack) {
+          var lines = stack.split('\n');
+          var matchingLine = lines.findIndex((line) => line.indexOf('ts_document_parse') !== -1);
+          if (matchingLine !== -1) {
+            return lines.slice(0, matchingLine + 1).join('\n') + '\n' + lines[lines.length - 1]
+          } else {
+            return null;
+          }
+        })
+        .filter(function (stack) { return !!stack })
+        .join('\n\n');
+
+      stackvisProcess.stdin.write(filteredOutput);
+      stackvisProcess.stdin.end();
+
+      stackvisProcess.on('close', function(code) {
+        if (code !== 0) {
+          return callback(code);
+        }
+
+        console.log("Opening", flamegraphFile.path);
+        spawn('open', [flamegraphFile.path]);
+        callback(0);
+      });
+    });
+
+    return
+  }
+
   document.setInputString(fs.readFileSync(options.codePath, 'utf8'));
 
+  // If running more than once, force JS code to be optimized ahead-of-time, so
+  // that the optimization time is not counted.
+  if (options.repeat > 1) {
+    for (var i = 0; i < 10; i++) {
+      document.invalidate().parse();
+    }
+  }
+
   var t0 = Date.now()
-  document.parse();
+  for (var i = 0; i < options.repeat; i++) {
+    document.invalidate().parse();
+  }
   var t1 = Date.now();
 
   if (options.print) {
     printNode(document.rootNode, 0);
     process.stdout.write("\n");
-  } else if (document.rootNode.toString().indexOf('ERROR') !== -1) {
-    console.log("Error detected")
-    process.exit(1)
   }
 
-  console.log("Finished in %d milliseconds", t1 - t0);
+  console.log("Parsed in %d milliseconds", (t1 - t0) / options.repeat);
+
+  if (document.rootNode.toString().indexOf('ERROR') !== -1) {
+    console.log("Error detected")
+    callback(1);
+  } else {
+    callback(0);
+  }
 };
 
 function printNode (node, indentLevel) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fs-extra": "^0.18.2",
     "mkdirp": "*",
     "nan": "^2.0.0",
+    "stackvis": "^0.3.0",
     "temp": "0.7.x",
     "tree-sitter": ">= 0.0.41",
     "vows": "0.7.x",


### PR DESCRIPTION
```sh
$ cd tree-sitter-javascript
$ tree-sitter parse /tmp/jquery.js --profile --repeat=10

# Opens this flame graph in a web browser:
```

![profile-output](https://cloud.githubusercontent.com/assets/326587/12827866/a3199c90-cb36-11e5-9c0f-89d80d54ae75.png)

One useful finding from this is that the recursive function `ts_tree_release` can use a *lot* of stack frames. This is probably a security risk for the library. That function probably needs to be rewritten using an explicit stack and a loop, or optimized in some way.