### PR TITLE
Grammar builder ergonomics — throw if incorrect signature used

### DIFF
--- a/lib/api/dsl.js
+++ b/lib/api/dsl.js
@@ -67,15 +67,15 @@ prec.right = function(number, rule) {
   };
 }
 
-prec.dynamic = function(number, rule) {
+prec.dynamic = maxArgs(function(number, rule) {
   return {
     type: "PREC_DYNAMIC",
     value: number,
     content: normalize(rule)
   };
-}
+}, 'prec.dynamic')
 
-function alias(rule, value) {
+const alias = maxArgs(function alias(rule, value) {
   const result = {
     type: "ALIAS",
     content: normalize(rule)
@@ -99,21 +99,21 @@ function alias(rule, value) {
   }
 
   throw new Error('Invalid alias value ' + value);
-}
+})
 
-function repeat(rule) {
+const repeat = maxArgs(function repeat(rule) {
   return {
     type: "REPEAT",
     content: normalize(rule)
   };
-}
+})
 
-function repeat1(rule) {
+const repeat1 = maxArgs(function repeat1(rule) {
   return {
     type: "REPEAT1",
     content: normalize(rule)
   };
-}
+})
 
 function seq(...elements) {
   return {
@@ -136,23 +136,23 @@ function sym(name) {
   };
 }
 
-function token(value) {
+const token = maxArgs(function token(value) {
   return {
     type: "TOKEN",
     content: normalize(value)
   };
-}
+})
 
-token.immediate = function(value) {
+token.immediate = maxArgs(function(value) {
   return {
     type: "IMMEDIATE_TOKEN",
     content: normalize(value)
   };
-}
+}, 'token.immediate')
 
-function optional(value) {
+const optional = maxArgs(function optional(value) {
   return choice(value, blank());
-}
+})
 
 function normalize(value) {
   if (typeof value == "undefined")
@@ -306,6 +306,34 @@ function grammar(baseGrammar, options) {
 
   return {name, word, rules, extras, conflicts, externals, inline};
 }
+
+function maxArgs(f, name=f.name, needed=f.length) {
+  return function (...args) {
+    const given = args.length
+    if (given !== needed)
+      throw new Error(`${
+        name
+      } ${
+        describeArgCount(needed)
+      }, but ${given} were given. ${
+        suggestArgFix(needed, given)
+      }`)
+    return f.apply(this, args)
+  }
+}
+
+const describeArgCount = needed =>
+  needed === 1
+    ? 'takes a single argument'
+    :
+  `takes ${needed} arguments`
+
+const suggestArgFix = (needed, given) =>
+  `Did you mean to use ${
+    needed > given
+      ? 'blank()'
+      : 'seq()'
+  }?`
 
 module.exports = {
   alias: alias,

--- a/test/grammar_test.js
+++ b/test/grammar_test.js
@@ -126,6 +126,28 @@ describe("Writing a grammar", () => {
         tree = parser.parse("ooo");
         assert.equal(tree.rootNode.toString(), "(the_rule)");
       });
+
+      it("throws if called with multiple arguments", () => {
+        let error = null;
+        try {
+          repeat('x', 'y');
+        } catch (e) {
+          error = e;
+        }
+        assert.propertyVal(error, 'message',
+          `repeat takes a single argument, but 2 were given. Did you mean to use seq()?`)        
+      });
+
+      it("throws if called with no arguments", () => {
+        let error = null;
+        try {
+          repeat();
+        } catch (e) {
+          error = e;
+        }
+        assert.propertyVal(error, 'message',
+          `repeat takes a single argument, but 0 were given. Did you mean to use blank()?`)
+      });
     });
 
     describe("sequence", () => {


### PR DESCRIPTION
Specifically, throw if grammar builder functions are passed wrong number of args. This catches the common (for me) problem of doing something like `optional('+', $.term)` when I meant to do `optional(seq('+', term))`.