### PR TITLE
Add notice that the repo is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ Incremental parsers for node
 [![Build Status](https://travis-ci.org/tree-sitter/tree-sitter-cli.svg?branch=master)](https://travis-ci.org/tree-sitter/tree-sitter-cli)
 [![Build status](https://ci.appveyor.com/api/projects/status/t9775gnhcnsb5na1/branch/master?svg=true)](https://ci.appveyor.com/project/maxbrunsfeld/tree-sitter-cli/branch/master)
 
+---
+
+:warning: This repository is deprecated. :warning:
+
+The source code for the Tree-sitter CLI is now part of [the main Tree-sitter repository](https://github.com/tree-sitter/tree-sitter).
+
+---
+
 ### Installation
 
 ```


### PR DESCRIPTION
The Tree-sitter CLI has been re-implemented in Rust, and the code is now part of [the main Tree-sitter repository](https://github.com/tree-sitter).

The JavaScript unit tests from this repository have been moved into [`node-tree-sitter`](https://github.com/tree-sitter/node-tree-sitter).

This repository is no longer needed.

However, you can still install `tree-sitter-cli` from NPM. Installing that module will just download a single pre-built binary for your platform.

For more information, see this pull request: https://github.com/tree-sitter/tree-sitter/pull/260.
